### PR TITLE
Allow dependency up to google-auth major version 3x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = codecs.open('README.rst', "r").read()
 
 INSTALL_REQUIRES = [
     "google-api-python-client >= 1.8.2",
-    "google-auth >= 1.28.0,<2",
+    "google-auth >= 1.28.0,<3",
     "python-dateutil >= 2.5.3",
     "Django >= 2.2"
 ]


### PR DESCRIPTION
From what I can tell, [the major version bump between 1x and 2x](https://github.com/googleapis/google-auth-library-python/releases/tag/v2.0.0) was around dropping python 2x support. We don't need py2 support so this doesn't seem like it matters to us. 